### PR TITLE
SE-1239 Applies upstream patches

### DIFF
--- a/lms/templates/support/certificates.html
+++ b/lms/templates/support/certificates.html
@@ -1,6 +1,8 @@
+<%page expression_filter="h"/>
 <%!
 from django.urls import reverse
 from django.utils.translation import ugettext as _
+from openedx.core.djangolib.js_utils import js_escaped_string
 %>
 <%namespace name='static' file='../static_content.html'/>
 
@@ -9,8 +11,8 @@ from django.utils.translation import ugettext as _
 <%block name="js_extra">
 <%static:require_module module_name="support/js/certificates_factory" class_name="CertificatesFactory">
     new CertificatesFactory({
-        userFilter: '${ user_filter }',
-        courseFilter: '${course_filter}'
+        userFilter: '${ user_filter | n, js_escaped_string }',
+        courseFilter: '${ course_filter | n, js_escaped_string }'
     });
 </%static:require_module>
 </%block>

--- a/requirements/edx-sandbox/base.in
+++ b/requirements/edx-sandbox/base.in
@@ -8,4 +8,4 @@
 #   * run "make upgrade" to update the detailed requirements files
 
 -r shared.txt                       # Dependencies in common with LMS and Studio
-matplotlib==1.3.1                   # 2D plotting library
+matplotlib==1.5.3                   # 2D plotting library

--- a/requirements/edx-sandbox/base.txt
+++ b/requirements/edx-sandbox/base.txt
@@ -12,12 +12,13 @@ asn1crypto==0.24.0
 backports-abc==0.5        # via tornado
 cffi==1.11.5
 cryptography==2.2.2
+cycler==0.10.0            # via matplotlib
 enum34==1.1.6
 futures==3.2.0            # via tornado
 idna==2.7
 ipaddress==1.0.22
 lxml==3.8.0
-matplotlib==1.3.1
+matplotlib==1.5.3
 networkx==1.7
 nltk==3.3.0
 nose==1.3.7               # via matplotlib
@@ -25,6 +26,7 @@ numpy==1.6.2
 pycparser==2.18
 pyparsing==2.2.0
 python-dateutil==2.7.3    # via matplotlib
+pytz==2019.1              # via matplotlib
 scipy==0.14.0
 singledispatch==3.4.0.3   # via tornado
 six==1.11.0


### PR DESCRIPTION
Patches XSS vulnerability, and handles dependency issue with `matplotlib`/`numpy` which occurs during redeployment.

**Testing instructions**

epodx.org will be redeployed using this branch.

Verify updated service using the [manual instance checklist](https://gitlab.com/opencraft/documentation/private/blob/master/checklists/manual_instance_test.md).

**Reviewer**
- [ ] @toxinu ?